### PR TITLE
Remove underline de todos os links

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -43,6 +43,10 @@ hr {
     border-width: 8px;
 }
 
+a  {
+    text-decoration: none;
+}
+
 /* ARTICLE - TITLE ABOUT */
 .title {
     text-align: center;


### PR DESCRIPTION
- usado o seletor para que os links com tag <a> não possuam o underline. Todos os futuros também não terão, caso queira adicionar tem que remover essa linha